### PR TITLE
Support quick offline evaluation

### DIFF
--- a/btcp/model/evaluator.py
+++ b/btcp/model/evaluator.py
@@ -10,7 +10,7 @@ import numpy as np
 from tensorflow.keras.models import load_model
 from sklearn.preprocessing import MinMaxScaler
 
-from btcp.data.realtime import fetch_current_price
+from btcp.data.realtime import fetch_current_price, fetch_realtime_data
 
 
 SEQ_LENGTH = 60
@@ -70,6 +70,52 @@ def evaluate_realtime_model() -> None:
         wait_until_next_minute()
 
 
+def evaluate_recent_hour() -> None:
+    """Quickly evaluate using the last hour of historical minute data."""
+
+    model = load_model(MODEL_PATH)
+    scaler = MinMaxScaler()
+
+    lookback = SEQ_LENGTH + max(PRED_OFFSETS) + 60
+    df = fetch_realtime_data(lookback=lookback)
+    prices = df["close"].astype(float).tolist()
+    times = df["timestamp"].tolist()
+
+    start = SEQ_LENGTH
+    end = start + 60
+    print("[INFO] 최근 1시간 데이터로 빠른 검증 시작...")
+
+    for idx in range(start, end):
+        seq = np.array(prices[idx - SEQ_LENGTH:idx], dtype=float).reshape(-1, 1)
+        scaled = scaler.fit_transform(seq)
+        x = scaled.reshape(1, SEQ_LENGTH, 1)
+        pred_scaled = model.predict(x)[0]
+        pred_prices = scaler.inverse_transform(pred_scaled.reshape(-1, 1)).flatten()
+
+        actuals = [prices[idx + off] for off in PRED_OFFSETS]
+        errors = [abs(actuals[i] - pred_prices[i]) for i in range(len(PRED_OFFSETS))]
+        ts = datetime.fromtimestamp(times[idx] / 1000)
+        print(f"[EVAL] {ts.strftime('%Y-%m-%d %H:%M')} 기준 예측 오차:")
+        for off, err in zip(PRED_OFFSETS, errors):
+            print(f" {off}분 후 오차: {err:.2f}")
+
+
+
 if __name__ == "__main__":
-    evaluate_realtime_model()
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Evaluate model predictions in real time or using recent data"
+    )
+    parser.add_argument(
+        "--recent",
+        action="store_true",
+        help="Use the last hour of data instead of waiting in real time",
+    )
+    args = parser.parse_args()
+
+    if args.recent:
+        evaluate_recent_hour()
+    else:
+        evaluate_realtime_model()
 


### PR DESCRIPTION
## Summary
- allow evaluator to fetch recent price history
- add `evaluate_recent_hour` for quick evaluation on existing data
- expose CLI `--recent` flag to choose historical vs realtime evaluation

## Testing
- `python -m py_compile btcp/model/evaluator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6857e475067083329994e22d646d0baf